### PR TITLE
Mipgap

### DIFF
--- a/src/solvers/cbc.rs
+++ b/src/solvers/cbc.rs
@@ -204,3 +204,105 @@ impl SolverProgram for CbcSolver {
         self.temp_solution_file.as_deref()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::solvers::{CbcSolver, SolverProgram, WithMaxSeconds, WithMipGap, WithNbThreads};
+    use std::ffi::OsString;
+    use std::path::Path;
+
+    #[test]
+    fn cli_args_default() {
+        let lp_file = Path::new("test.lp");
+        let sol_file = Path::new("test.sol");
+
+        let solver = CbcSolver::new();
+        let args = solver.arguments(lp_file, sol_file);
+
+        let expected: Vec<OsString> = vec![
+            lp_file.into(),
+            "solve".into(),
+            "solution".into(),
+            sol_file.into(),
+        ];
+
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn cli_args_seconds() {
+        let lp_file = Path::new("test.lp");
+        let sol_file = Path::new("test.sol");
+        let seconds = 10;
+
+        let solver = CbcSolver::new().with_max_seconds(seconds);
+        let args = solver.arguments(lp_file, sol_file);
+
+        let expected: Vec<OsString> = vec![
+            lp_file.into(),
+            "seconds".into(),
+            seconds.to_string().into(),
+            "solve".into(),
+            "solution".into(),
+            sol_file.into(),
+        ];
+
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn cli_args_mipgap() {
+        let lp_file = Path::new("test.lp");
+        let sol_file = Path::new("test.sol");
+        let mipgap = 0.05;
+
+        let solver = CbcSolver::new()
+            .with_mip_gap(mipgap)
+            .expect("mipgap should be valid");
+        let args = solver.arguments(lp_file, sol_file);
+
+        let expected: Vec<OsString> = vec![
+            lp_file.into(),
+            "ratiogap".into(),
+            mipgap.to_string().into(),
+            "solve".into(),
+            "solution".into(),
+            sol_file.into(),
+        ];
+
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn cli_args_mipgap_negative() {
+        let solver = CbcSolver::new().with_mip_gap(-0.05);
+        assert!(solver.is_err());
+    }
+
+    #[test]
+    fn cli_args_mipgap_infinite() {
+        let solver = CbcSolver::new().with_mip_gap(f32::INFINITY);
+        assert!(solver.is_err());
+    }
+
+    #[test]
+    fn cli_args_threads() {
+        let lp_file = Path::new("test.lp");
+        let sol_file = Path::new("test.sol");
+        let threads = 2;
+
+        let solver = CbcSolver::new().with_nb_threads(threads);
+        let args = solver.arguments(lp_file, sol_file);
+
+        let expected: Vec<OsString> = vec![
+            lp_file.into(),
+            "threads".into(),
+            threads.to_string().into(),
+            "solve".into(),
+            "solution".into(),
+            sol_file.into(),
+        ];
+
+        assert_eq!(args, expected);
+    }
+}

--- a/src/solvers/cbc.rs
+++ b/src/solvers/cbc.rs
@@ -48,8 +48,8 @@ impl CbcSolver {
             name: self.name.clone(),
             command_name,
             temp_solution_file: self.temp_solution_file.clone(),
-            threads: None,
-            seconds: None,
+            threads: self.threads,
+            seconds: self.seconds,
             mipgap: self.mipgap,
         }
     }
@@ -60,8 +60,8 @@ impl CbcSolver {
             name: self.name.clone(),
             command_name: self.command_name.clone(),
             temp_solution_file: Some(temp_solution_file.into()),
-            threads: None,
-            seconds: None,
+            threads: self.threads,
+            seconds: self.seconds,
             mipgap: self.mipgap,
         }
     }

--- a/src/solvers/cbc.rs
+++ b/src/solvers/cbc.rs
@@ -151,13 +151,13 @@ impl WithMipGap<CbcSolver> for CbcSolver {
     }
 
     fn with_mip_gap(&self, mipgap: f32) -> Result<CbcSolver, String> {
-        if mipgap >= 0.0 {
+        if mipgap.is_sign_positive() && mipgap.is_finite() {
             Ok(CbcSolver {
                 mipgap: Some(mipgap),
                 ..(*self).clone()
             })
         } else {
-            Err("Invalid MIP gap: must be >= 0".to_string())
+            Err("Invalid MIP gap: must be positive and finite".to_string())
         }
     }
 }

--- a/src/solvers/cbc.rs
+++ b/src/solvers/cbc.rs
@@ -213,17 +213,14 @@ mod tests {
 
     #[test]
     fn cli_args_default() {
-        let lp_file = Path::new("test.lp");
-        let sol_file = Path::new("test.sol");
-
         let solver = CbcSolver::new();
-        let args = solver.arguments(lp_file, sol_file);
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
 
         let expected: Vec<OsString> = vec![
-            lp_file.into(),
+            "test.lp".into(),
             "solve".into(),
             "solution".into(),
-            sol_file.into(),
+            "test.sol".into(),
         ];
 
         assert_eq!(args, expected);
@@ -231,20 +228,16 @@ mod tests {
 
     #[test]
     fn cli_args_seconds() {
-        let lp_file = Path::new("test.lp");
-        let sol_file = Path::new("test.sol");
-        let seconds = 10;
-
-        let solver = CbcSolver::new().with_max_seconds(seconds);
-        let args = solver.arguments(lp_file, sol_file);
+        let solver = CbcSolver::new().with_max_seconds(10);
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
 
         let expected: Vec<OsString> = vec![
-            lp_file.into(),
+            "test.lp".into(),
             "seconds".into(),
-            seconds.to_string().into(),
+            "10".into(),
             "solve".into(),
             "solution".into(),
-            sol_file.into(),
+            "test.sol".into(),
         ];
 
         assert_eq!(args, expected);
@@ -252,22 +245,19 @@ mod tests {
 
     #[test]
     fn cli_args_mipgap() {
-        let lp_file = Path::new("test.lp");
-        let sol_file = Path::new("test.sol");
-        let mipgap = 0.05;
-
         let solver = CbcSolver::new()
-            .with_mip_gap(mipgap)
+            .with_mip_gap(0.05)
             .expect("mipgap should be valid");
-        let args = solver.arguments(lp_file, sol_file);
+
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
 
         let expected: Vec<OsString> = vec![
-            lp_file.into(),
+            "test.lp".into(),
             "ratiogap".into(),
-            mipgap.to_string().into(),
+            "0.05".to_string().into(),
             "solve".into(),
             "solution".into(),
-            sol_file.into(),
+            "test.sol".into(),
         ];
 
         assert_eq!(args, expected);
@@ -287,20 +277,16 @@ mod tests {
 
     #[test]
     fn cli_args_threads() {
-        let lp_file = Path::new("test.lp");
-        let sol_file = Path::new("test.sol");
-        let threads = 2;
-
-        let solver = CbcSolver::new().with_nb_threads(threads);
-        let args = solver.arguments(lp_file, sol_file);
+        let solver = CbcSolver::new().with_nb_threads(3);
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
 
         let expected: Vec<OsString> = vec![
-            lp_file.into(),
+            "test.lp".into(),
             "threads".into(),
-            threads.to_string().into(),
+            "3".into(),
             "solve".into(),
             "solution".into(),
-            sol_file.into(),
+            "test.sol".into(),
         ];
 
         assert_eq!(args, expected);

--- a/src/solvers/cbc.rs
+++ b/src/solvers/cbc.rs
@@ -291,4 +291,30 @@ mod tests {
 
         assert_eq!(args, expected);
     }
+
+    #[test]
+    fn cli_args_multiple() {
+        let solver = CbcSolver::new()
+            .with_nb_threads(3)
+            .with_max_seconds(10)
+            .with_mip_gap(0.05)
+            .expect("mipgap should be valid");
+
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
+
+        let expected: Vec<OsString> = vec![
+            "test.lp".into(),
+            "ratiogap".into(),
+            "0.05".into(),
+            "seconds".into(),
+            "10".into(),
+            "threads".into(),
+            "3".into(),
+            "solve".into(),
+            "solution".into(),
+            "test.sol".into(),
+        ];
+
+        assert_eq!(args, expected);
+    }
 }

--- a/src/solvers/cplex.rs
+++ b/src/solvers/cplex.rs
@@ -139,3 +139,56 @@ impl SolverWithSolutionParsing for Cplex {
         Ok(solution)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::solvers::{Cplex, SolverProgram, WithMipGap};
+    use std::ffi::OsString;
+    use std::path::Path;
+
+    #[test]
+    fn cli_args_default() {
+        let solver = Cplex::default();
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
+
+        let expected: Vec<OsString> = vec![
+            "-c".into(),
+            "READ \"test.lp\"".into(),
+            "optimize".into(),
+            "WRITE \"test.sol\"".into(),
+        ];
+
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn cli_args_mipgap() {
+        let solver = Cplex::default()
+            .with_mip_gap(0.5)
+            .expect("mipgap should be valid");
+
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
+
+        let expected: Vec<OsString> = vec![
+            "-c".into(),
+            "READ \"test.lp\"".into(),
+            "set mip tolerances mipgap 0.5".into(),
+            "optimize".into(),
+            "WRITE \"test.sol\"".into(),
+        ];
+
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn cli_args_mipgap_negative() {
+        let solver = Cplex::default().with_mip_gap(-0.05);
+        assert!(solver.is_err());
+    }
+
+    #[test]
+    fn cli_args_mipgap_infinite() {
+        let solver = Cplex::default().with_mip_gap(f32::INFINITY);
+        assert!(solver.is_err());
+    }
+}

--- a/src/solvers/glpk.rs
+++ b/src/solvers/glpk.rs
@@ -148,13 +148,13 @@ impl WithMipGap<GlpkSolver> for GlpkSolver {
     }
 
     fn with_mip_gap(&self, mipgap: f32) -> Result<GlpkSolver, String> {
-        if mipgap >= 0.0 {
+        if mipgap.is_sign_positive() && mipgap.is_finite() {
             Ok(GlpkSolver {
                 mipgap: Some(mipgap),
                 ..(*self).clone()
             })
         } else {
-            Err("Invalid MIP gap: must be >= 0".to_string())
+            Err("Invalid MIP gap: must be positive and finite".to_string())
         }
     }
 }

--- a/src/solvers/glpk.rs
+++ b/src/solvers/glpk.rs
@@ -198,34 +198,27 @@ mod tests {
 
     #[test]
     fn cli_args_default() {
-        let lp_file = Path::new("test.lp");
-        let sol_file = Path::new("test.sol");
-
         let solver = GlpkSolver::new();
-        let args = solver.arguments(lp_file, sol_file);
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
 
         let expected: Vec<OsString> =
-            vec!["--lp".into(), lp_file.into(), "-o".into(), sol_file.into()];
+            vec!["--lp".into(), "test.lp".into(), "-o".into(), "test.sol".into()];
 
         assert_eq!(args, expected);
     }
 
     #[test]
     fn cli_args_seconds() {
-        let lp_file = Path::new("test.lp");
-        let sol_file = Path::new("test.sol");
-        let seconds = 10;
-
-        let solver = GlpkSolver::new().with_max_seconds(seconds);
-        let args = solver.arguments(lp_file, sol_file);
+        let solver = GlpkSolver::new().with_max_seconds(10);
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
 
         let expected: Vec<OsString> = vec![
             "--lp".into(),
-            lp_file.into(),
+            "test.lp".into(),
             "-o".into(),
-            sol_file.into(),
+            "test.sol".into(),
             "--tmlim".into(),
-            seconds.to_string().into(),
+            "10".into(),
         ];
 
         assert_eq!(args, expected);
@@ -233,22 +226,19 @@ mod tests {
 
     #[test]
     fn cli_args_mipgap() {
-        let lp_file = Path::new("test.lp");
-        let sol_file = Path::new("test.sol");
-        let mipgap = 0.05;
-
         let solver = GlpkSolver::new()
-            .with_mip_gap(mipgap)
+            .with_mip_gap(0.05)
             .expect("mipgap should be valid");
-        let args = solver.arguments(lp_file, sol_file);
+
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
 
         let expected: Vec<OsString> = vec![
             "--lp".into(),
-            lp_file.into(),
+            "test.lp".into(),
             "-o".into(),
-            sol_file.into(),
+            "test.sol".into(),
             "--mipgap".into(),
-            mipgap.to_string().into(),
+            "0.05".into(),
         ];
 
         assert_eq!(args, expected);

--- a/src/solvers/glpk.rs
+++ b/src/solvers/glpk.rs
@@ -201,8 +201,12 @@ mod tests {
         let solver = GlpkSolver::new();
         let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
 
-        let expected: Vec<OsString> =
-            vec!["--lp".into(), "test.lp".into(), "-o".into(), "test.sol".into()];
+        let expected: Vec<OsString> = vec![
+            "--lp".into(),
+            "test.lp".into(),
+            "-o".into(),
+            "test.sol".into(),
+        ];
 
         assert_eq!(args, expected);
     }
@@ -254,5 +258,28 @@ mod tests {
     fn cli_args_mipgap_infinite() {
         let solver = GlpkSolver::new().with_mip_gap(f32::INFINITY);
         assert!(solver.is_err());
+    }
+
+    #[test]
+    fn cli_args_multiple() {
+        let solver = GlpkSolver::new()
+            .with_max_seconds(10)
+            .with_mip_gap(0.05)
+            .expect("mipgap should be valid");
+
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
+
+        let expected: Vec<OsString> = vec![
+            "--lp".into(),
+            "test.lp".into(),
+            "-o".into(),
+            "test.sol".into(),
+            "--tmlim".into(),
+            "10".into(),
+            "--mipgap".into(),
+            "0.05".into(),
+        ];
+
+        assert_eq!(args, expected);
     }
 }

--- a/src/solvers/gurobi.rs
+++ b/src/solvers/gurobi.rs
@@ -146,15 +146,12 @@ mod tests {
 
     #[test]
     fn cli_args_default() {
-        let lp_file = "test.lp".to_string();
-        let sol_file = "test.sol".to_string();
-
         let solver = GurobiSolver::new();
-        let args = solver.arguments(Path::new(&lp_file), Path::new(&sol_file));
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
 
         let expected: Vec<OsString> = vec![
-            ("ResultFile=".to_string() + &sol_file).into(),
-            lp_file.into(),
+            "ResultFile=test.sol".into(),
+            "test.lp".into(),
         ];
 
         assert_eq!(args, expected);
@@ -162,19 +159,16 @@ mod tests {
 
     #[test]
     fn cli_args_mipgap() {
-        let lp_file = "test.lp".to_string();
-        let sol_file = "test.sol".to_string();
-        let mipgap = 0.05;
-
         let solver = GurobiSolver::new()
-            .with_mip_gap(mipgap)
+            .with_mip_gap(0.05)
             .expect("mipgap should be valid");
-        let args = solver.arguments(Path::new(&lp_file), Path::new(&sol_file));
+
+        let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
 
         let expected: Vec<OsString> = vec![
-            ("ResultFile=".to_string() + &sol_file).into(),
-            ("MIPGap=".to_string() + &mipgap.to_string()).into(),
-            lp_file.into(),
+            "ResultFile=test.sol".into(),
+            "MIPGap=0.05".into(),
+            "test.lp".into(),
         ];
 
         assert_eq!(args, expected);

--- a/src/solvers/gurobi.rs
+++ b/src/solvers/gurobi.rs
@@ -90,13 +90,13 @@ impl WithMipGap<GurobiSolver> for GurobiSolver {
     }
 
     fn with_mip_gap(&self, mipgap: f32) -> Result<GurobiSolver, String> {
-        if mipgap >= 0.0 {
+        if mipgap.is_sign_positive() && mipgap.is_finite() {
             Ok(GurobiSolver {
                 mipgap: Some(mipgap),
                 ..(*self).clone()
             })
         } else {
-            Err("Invalid MIP gap: must be >= 0".to_string())
+            Err("Invalid MIP gap: must be positive and finite".to_string())
         }
     }
 }

--- a/src/solvers/gurobi.rs
+++ b/src/solvers/gurobi.rs
@@ -137,3 +137,58 @@ impl SolverProgram for GurobiSolver {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::solvers::{GurobiSolver, SolverProgram, WithMipGap};
+    use std::ffi::OsString;
+    use std::path::Path;
+
+    #[test]
+    fn cli_args_default() {
+        let lp_file = "test.lp".to_string();
+        let sol_file = "test.sol".to_string();
+
+        let solver = GurobiSolver::new();
+        let args = solver.arguments(Path::new(&lp_file), Path::new(&sol_file));
+
+        let expected: Vec<OsString> = vec![
+            ("ResultFile=".to_string() + &sol_file).into(),
+            lp_file.into(),
+        ];
+
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn cli_args_mipgap() {
+        let lp_file = "test.lp".to_string();
+        let sol_file = "test.sol".to_string();
+        let mipgap = 0.05;
+
+        let solver = GurobiSolver::new()
+            .with_mip_gap(mipgap)
+            .expect("mipgap should be valid");
+        let args = solver.arguments(Path::new(&lp_file), Path::new(&sol_file));
+
+        let expected: Vec<OsString> = vec![
+            ("ResultFile=".to_string() + &sol_file).into(),
+            ("MIPGap=".to_string() + &mipgap.to_string()).into(),
+            lp_file.into(),
+        ];
+
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn cli_args_mipgap_negative() {
+        let solver = GurobiSolver::new().with_mip_gap(-0.05);
+        assert!(solver.is_err());
+    }
+
+    #[test]
+    fn cli_args_mipgap_infinite() {
+        let solver = GurobiSolver::new().with_mip_gap(f32::INFINITY);
+        assert!(solver.is_err());
+    }
+}

--- a/src/solvers/gurobi.rs
+++ b/src/solvers/gurobi.rs
@@ -149,10 +149,7 @@ mod tests {
         let solver = GurobiSolver::new();
         let args = solver.arguments(Path::new("test.lp"), Path::new("test.sol"));
 
-        let expected: Vec<OsString> = vec![
-            "ResultFile=test.sol".into(),
-            "test.lp".into(),
-        ];
+        let expected: Vec<OsString> = vec!["ResultFile=test.sol".into(), "test.lp".into()];
 
         assert_eq!(args, expected);
     }

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -206,6 +206,14 @@ pub trait WithNbThreads<T> {
     fn with_nb_threads(&self, threads: u32) -> T;
 }
 
+/// Configure the MIP (optimality) gap
+pub trait WithMipGap<T> {
+    /// get MIP gap
+    fn mip_gap(&self) -> Option<f32>;
+    /// set MIP gap
+    fn with_mip_gap(&self, mipgap: f32) -> Result<T, String>;
+}
+
 /// A static version of a solver, where the solver itself doesn't hold any data
 ///
 /// ```


### PR DESCRIPTION
Add a `WithMipGap` trait and implement it for CBC, Cplex, GLPK, and Gurobi.

While updating the CBC `command_name` and `with_temp_solution_file` methods I also changed them to copy `threads` and `seconds` from `self` instead of setting those values to `None`.  Most programmers probably expect those methods to retain set values instead of resetting them to `None`.

In the CBC `read_specific_solution` method I put `buffer.split_whitespace()` in a variable because the code now needs to call `next()` twice: once to look for `"Optimal"` and once to examine what follows to see if the status should be `SubOptimal`.

In the CBC `arguments` method I replaced the redundant setting of the timeout with the code to set the MIP gap.

In the Glpk `arguments` method I got rid of the iterator as suggested for the PR that implemented it.  Since `seconds` and `mipgap` have different types I couldn't just add another tuple to the array that was being iterated over.

I don't have access to Cplex or Gurobi command line interfaces so I couldn't verify that they work, nor do I know how to recognize when a solution is suboptimal for those solvers.  I relied solely on documentation to set the MIP gap arguments.
