### PR TITLE
Fixed issues setting Status for LpSolution when using Gurobi and WithMaxSeconds

### DIFF
--- a/src/solvers/cbc.rs
+++ b/src/solvers/cbc.rs
@@ -95,7 +95,7 @@ impl SolverWithSolutionParsing for CbcSolver {
                     if let Some(substatus) = buffer_split.next() {
                         match substatus {
                             // MIP gap stops are "Optimal (within gap tolerance)"
-                            "(within" => Status::SubOptimal,
+                            "(within" => Status::MipGap,
                             _ => Status::Optimal,
                         }
                     } else {

--- a/src/solvers/gurobi.rs
+++ b/src/solvers/gurobi.rs
@@ -156,13 +156,15 @@ impl SolverProgram for GurobiSolver {
     }
 
     fn parse_stdout_status(&self, stdout: &[u8]) -> Option<Status> {
-        if buf_contains(stdout, "Optimal solution found") {
+        if buf_contains(stdout, "Optimal solution found (tolerance 1.00e-04)") {
             Some(Status::Optimal)
+        } else if buf_contains(stdout, "Optimal solution found (tolerance ") {
+            Some(Status::MipGap)
         } else if buf_contains(stdout, "Time limit reached") {
             if buf_contains(stdout, "Best objective -,") {
                 Some(Status::NotSolved)
             } else {
-                Some(Status::SubOptimal)
+                Some(Status::TimeLimit)
             }
         } else if buf_contains(stdout, "infeasible") || buf_contains(stdout, "Infeasible model") {
             Some(Status::Infeasible)

--- a/src/solvers/gurobi.rs
+++ b/src/solvers/gurobi.rs
@@ -158,10 +158,14 @@ impl SolverProgram for GurobiSolver {
     fn parse_stdout_status(&self, stdout: &[u8]) -> Option<Status> {
         if buf_contains(stdout, "Optimal solution found") {
             Some(Status::Optimal)
-        } else if buf_contains(stdout, "infeasible") {
-            Some(Status::Infeasible)
         } else if buf_contains(stdout, "Time limit reached") {
-            Some(Status::SubOptimal)
+            if buf_contains(stdout, "Best objective -,") {
+                Some(Status::NotSolved)
+            } else {
+                Some(Status::SubOptimal)
+            }
+        } else if buf_contains(stdout, "infeasible") || buf_contains(stdout, "Infeasible model") {
+            Some(Status::Infeasible)
         } else {
             None
         }

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -51,6 +51,10 @@ pub mod gurobi;
 pub enum Status {
     /// the best possible solution was found
     Optimal,
+    /// The time limit was reached
+    TimeLimit,
+    /// The MipGap was reached
+    MipGap,
     /// A solution was found; it may not be the best one.
     SubOptimal,
     /// There is no solution for the problem


### PR DESCRIPTION
In #11 I have implemented `WithMaxSeconds` for Gurobi. I noticed some issues with the result status recognition, which I would like to fix. Sorry for the issues in the first place.

Also, I would like to implement `WithTimeLimit` in [good_lp](https://github.com/rust-or/good_lp) for `LpSolvers`. For this, I need to pass more information through `status` in `Solution` to return a correct `SolutionStatus` in [good_lp](https://github.com/rust-or/good_lp/blob/20d5f866b844c42f020fbcd007e1000127d8fcd4/src/solvers/mod.rs#L247). 

# Issues
## Instances stoped because of a reached time limit may be classified as infeasible
In the output of Gurobi, a node in the branching tree can be cut if it is *infeasible*. This may be printed to the `stdout`.
```    Nodes    |    Current Node    |     Objective Bounds      |     Work
 Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time

     0     0    0.00000    0    1    6.13778    0.00000   100%     -    0s
...
 63359  9106 infeasible   68         1.31365    0.00000   100%   7.5    5s

Cutting planes:
  Gomory: 1
  Clique: 1
  MIR: 1
  Flow cover: 8

Explored 64985 nodes (497258 simplex iterations) in 5.00 seconds (4.37 work units)
Thread count was 16 (of 16 available processors)

Solution count 10: 1.31365 1.45927 1.49338 ... 1.92356

Time limit reached
Best objective 1.313649132021e+00, best bound 0.000000000000e+00, gap 100.0000%
```
Since the `stdout` is checked first for **"infeasible"** and then **"Time limit reached"**, the status is then falsely `Infeasible`.

### Fix
First search for **"Time limit reached"** in `stdout`.

## Time limit reached but no solution found
When the solver is stopped due to a time limit, it maybe could not have found a solution in an feasable instance. Currently, the status would be `SubOptimal` even if no solution was found.
Example of an output of Gurobi:
```    Nodes    |    Current Node    |     Objective Bounds      |     Work
 Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time

     0     0    0.00000    0    6          -    0.00000      -     -    0s
     0     0    0.00000    0    6          -    0.00000      -     -    0s
     0     0    0.00000    0    6          -    0.00000      -     -    0s
     0     0    0.00000    0    6          -    0.00000      -     -    0s
     0     2    0.00000    0    6          -    0.00000      -     -    0s
 139077 18706    0.00000   48    7          -    0.00000      -   6.0    5s

Cutting planes:
  Gomory: 2
  Clique: 1
  MIR: 1
  Flow cover: 10
  RLT: 1
  Relax-and-lift: 6

Explored 139277 nodes (863033 simplex iterations) in 5.01 seconds (4.64 work units)
Thread count was 16 (of 16 available processors)

Solution count 0

Time limit reached
Best objective -, best bound 0.000000000000e+00, gap -
```

### Fix
Search for **"Best objectuve -,"** and set status depending on if the string is present in the `stdout`.

## Incomplete testing for infeasible model
Currently, the status is set to `Infeasible` if **"infeasible"** is contained in `stdout`. In the following Gurobi output, we give an infeasible instance that does not contain **"infeasible"** in its `stdout`.
```Optimize a model with 1 rows, 1 columns and 1 nonzeros
Model fingerprint: 0x5c876a1e
Coefficient statistics:
  Matrix range     [1e+00, 1e+00]
  Objective range  [1e+00, 1e+00]
  Bounds range     [2e+00, 2e+00]
  RHS range        [3e+00, 3e+00]
Presolve removed 0 rows and 1 columns
Presolve time: 0.00s

Solved in 0 iterations and 0.00 seconds (0.00 work units)
Infeasible model
```

### Fix
Add a check for **"Infeasible model"**.
It may be enough to only search for this string, but I could not exclude the possibility of Gurobi only returning **"infeasible"** in `stdout`.

Again, sorry for not catching these issues in the first place.